### PR TITLE
Add wing graphics around GitHub stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,93 +1,54 @@
-![MasterHead](https://raw.githubusercontent.com/erayysahin/erayysahin/main/eray-sahin-soft_63835231%20(1).png)
+# Hi there, I'm Eray! 👋
+
+<img src="https://raw.githubusercontent.com/erayysahin/erayysahin/main/eray-sahin-soft_63835231%20(1).png" alt="Banner" width="100%"/>
+
 ![](https://komarev.com/ghpvc/?username=erayysahin&color=blue)
-<div align="center">
- <a href="https://github.com/erayysahin">
-  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=28&duration=3000&pause=500&center=true&vCenter=true&width=435&lines=%e2%9c%a8+Eray+Şahin+%e2%9c%a8;%f0%9f%93%96+42+Kocaeli+Student+%f0%9f%93%96;%f0%9f%93%9a+Software+Developer+%f0%9f%92%bb;Welcome+To+My+Profile+%f0%9f%91%80" alt="Typing SVG" />
- </a>
-</div>
 
-
-- 🌱 I’m currently learning **ai**
-- 📫 How to reach me **eray_517_41@outlook.com**
-
-[![Leetcode Stats](https://leetcard.jacoblin.cool/erayysahin?theme=unicorn)](https://leetcode.com/eraysahin/)
-<h3 align="left">Connect with me:</h3>
-<p align="left">
-  <a href="https://github.com/404"><img src="https://user-images.githubusercontent.com/73097560/115834477-dbab4500-a447-11eb-908a-139a6edaec5c.gif"></a>
-<a href="https://dev.to/erayysahin" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/devto.svg" alt="erayysahin" height="30" width="40" /></a>
-<a href="https://linkedin.com/in/eray-şahin-817908306" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="eray-şahin-817908306" height="30" width="40" /></a>
-<a href="https://stackoverflow.com/users/24716168" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/stack-overflow.svg" alt="24716168" height="30" width="40" /></a>
-<a href="https://instagram.com/eray_sahin18" target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/instagram.svg" alt="eray_sahin18" height="30" width="40" /></a>
-<a href="https://discord.gg/.asauchi." target="blank"><img align="center" src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/discord.svg" alt=".asauchi." height="30" width="40" /></a>
-  <a href="https://github.com/404"><img src="https://user-images.githubusercontent.com/73097560/115834477-dbab4500-a447-11eb-908a-139a6edaec5c.gif"></a>
+<p align="center">
+  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=28&duration=3000&pause=500&center=true&vCenter=true&width=435&lines=%E2%9C%A8+Eray+%C5%9Eahin+%E2%9C%A8;%F0%9F%93%96+42+Kocaeli+Student+%F0%9F%93%96;%F0%9F%93%9A+Software+Developer+%F0%9F%92%BB;Welcome+To+My+Profile+%F0%9F%91%80" alt="Typing" />
 </p>
 
-<h3 align="left">Languages and Tools:</h3>
-<p align="left"> 
- <a href="https://github.com/404"><img src="https://user-images.githubusercontent.com/73097560/115834477-dbab4500-a447-11eb-908a-139a6edaec5c.gif"></a>
- <a href="https://www.cprogramming.com/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/c/c-original.svg" alt="c" width="40" height="40"/> </a> <a href="https://www.w3schools.com/cs/" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/csharp/csharp-original.svg" alt="csharp" width="40" height="40"/> </a> <a href="https://www.php.net" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="php" width="40" height="40"/> </a> <a href="https://www.python.org" target="_blank" rel="noreferrer"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/> </a> 
- <a href="https://github.com/404"><img src="https://user-images.githubusercontent.com/73097560/115834477-dbab4500-a447-11eb-908a-139a6edaec5c.gif"></a>
+## About Me
+
+- 🌱 I’m currently learning **AI**
+- 📫 Reach me at **eray_517_41@outlook.com**
+
+[![LeetCode Stats](https://leetcard.jacoblin.cool/erayysahin?theme=unicorn)](https://leetcode.com/eraysahin/)
+
+## Connect With Me
+
+<p align="left">
+  <a href="https://dev.to/erayysahin" target="_blank"><img src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/devto.svg" alt="Dev.to" height="30" width="40" /></a>
+  <a href="https://linkedin.com/in/eray-%C5%9Fahin-817908306" target="_blank"><img src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg" alt="LinkedIn" height="30" width="40" /></a>
+  <a href="https://stackoverflow.com/users/24716168" target="_blank"><img src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/stack-overflow.svg" alt="Stack Overflow" height="30" width="40" /></a>
+  <a href="https://instagram.com/eray_sahin18" target="_blank"><img src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/instagram.svg" alt="Instagram" height="30" width="40" /></a>
+  <a href="https://discord.gg/.asauchi." target="_blank"><img src="https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/discord.svg" alt="Discord" height="30" width="40" /></a>
+</p>
+
+## Languages & Tools
+
+<p align="left">
+  <a href="https://www.cprogramming.com/" target="_blank"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/c/c-original.svg" alt="C" width="40" height="40"/></a>
+  <a href="https://www.w3schools.com/cs/" target="_blank"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/csharp/csharp-original.svg" alt="C#" width="40" height="40"/></a>
+  <a href="https://www.php.net" target="_blank"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/php/php-original.svg" alt="PHP" width="40" height="40"/></a>
+  <a href="https://www.python.org" target="_blank"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="Python" width="40" height="40"/></a>
 </p>
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/CagatayAkkas/CagatayAkkas/output/github-contribution-grid-snake-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/CagatayAkkas/CagatayAkkas/output/github-contribution-grid-snake.svg">
-  <img alt="github contribution grid snake animation" src="https://raw.githubusercontent.com/CagatayAkkas/CagatayAkkas/output/github-contribution-grid-snake.svg">
+  <img alt="GitHub contribution grid snake animation" src="https://raw.githubusercontent.com/CagatayAkkas/CagatayAkkas/output/github-contribution-grid-snake.svg">
 </picture>
 
-# Github Stats
+## GitHub Stats
 
- <br />
- 
-  <p align="center">
-  <a>
-    <img heigth="160" width="182" src="https://github.com/erayysahin/erayysahin/blob/5da4503f94509344e2fd87d4f8bcc801c4d8fec6/ErayySahin-main/img/Bird%20Wing%20Left.png">
-      <img align="center" src="https://github-readme-stats.vercel.app/api?username=erayysahin&theme=material-palenight&hide_border=false&include_all_commits=false&count_private=false" alt="CagatayAkkas" />
-    <img heigth="160" width="182" src="https://github.com/erayysahin/erayysahin/blob/5da4503f94509344e2fd87d4f8bcc801c4d8fec6/ErayySahin-main/img/Bird%20Wing%20Right.png">
-  </a>
+<p align="center">
+  <img height="160" width="182" src="https://raw.githubusercontent.com/erayysahin/erayysahin/5da4503f94509344e2fd87d4f8bcc801c4d8fec6/ErayySahin-main/img/Bird%20Wing%20Left.png" alt="Wing left" />
+  <img align="center" src="https://github-readme-stats.vercel.app/api?username=erayysahin&theme=material-palenight&hide_border=false&include_all_commits=false&count_private=false" alt="GitHub Stats" />
+  <img height="160" width="182" src="https://raw.githubusercontent.com/erayysahin/erayysahin/5da4503f94509344e2fd87d4f8bcc801c4d8fec6/ErayySahin-main/img/Bird%20Wing%20Right.png" alt="Wing right" />
 </p>
-
-  
-<br />
-
-
- 
- <p align="center">
-  <a>
-    <img heigth="160" width="182" src="https://github.com/erayysahin/erayysahin/blob/5da4503f94509344e2fd87d4f8bcc801c4d8fec6/ErayySahin-main/img/Bird%20Wing%20Bottom%20Left.png">
-    <img align="center" src="https://github-readme-streak-stats.herokuapp.com/?user=erayysahin&theme=material-palenight&hide_border=false" alt="CagatayAkkas" width="55%" />
-    <img heigth="160" width="182" src="https://github.com/erayysahin/erayysahin/blob/5da4503f94509344e2fd87d4f8bcc801c4d8fec6/ErayySahin-main/img/Bird%20Wing%20Bottom%20Right.png">
-  </a>
+<p align="center">
+  <img height="160" width="182" src="https://raw.githubusercontent.com/erayysahin/erayysahin/5da4503f94509344e2fd87d4f8bcc801c4d8fec6/ErayySahin-main/img/Bird%20Wing%20Bottom%20Left.png" alt="Wing bottom left" />
+  <img align="center" width="55%" src="https://github-readme-streak-stats.herokuapp.com/?user=erayysahin&theme=material-palenight&hide_border=false" alt="GitHub Streak" />
+  <img height="160" width="182" src="https://raw.githubusercontent.com/erayysahin/erayysahin/5da4503f94509344e2fd87d4f8bcc801c4d8fec6/ErayySahin-main/img/Bird%20Wing%20Bottom%20Right.png" alt="Wing bottom right" />
 </p>
- 
-
- 
- <br />
- 
-  
-  
-  <!--<p align="center">
-  <a>
-    <img heigth="160" width="182" src="https://github.com/CagatayAkkas/CagatayAkkas/blob/main/img/Bird%20Wing%20Bottom%20Left.png">
-    <img align="center" src="https://github-readme-stats.vercel.app/api/top-langs/?username=erayysahin&theme=material-palenight&hide_border=false&include_all_commits=false&count_private=false&layout=compact" alt="CagatayAkkas" />
-    <img heigth="160" width="182" src="https://github.com/CagatayAkkas/CagatayAkkas/blob/main/img/Bird%20Wing%20Bottom%20Right.png">
-  </a>
-</p>
- 
-  
-  
- <!--
- [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=CagatayAkkas&layout=compact&langs_count=25&title_color=0000ee&text_color=ffffff&bg_color=000000&hide_border=true)](https://github.com/CagatayAkkas/github-readme-stats)
-
-
-<!--
-<br />
-
-![](https://github-profile-trophy.vercel.app/?username=erayysahin&theme=dracula&no-frame=false&no-bg=false&margin-w=4)
-
-
-<br />
-
-
-<br />
--->


### PR DESCRIPTION
## Summary
- add missing wing images around stats in README

## Testing
- `pytest -q`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6847302f5448832195d9c977e4431678